### PR TITLE
Remove deprecated 'Forem.theme =' option

### DIFF
--- a/lib/forem-theme-orange.rb
+++ b/lib/forem-theme-orange.rb
@@ -3,7 +3,6 @@ module Forem
   module Theme
     module Orange
       class Engine < Rails::Engine
-        Forem.theme = :orange
       end
     end
   end


### PR DESCRIPTION
I understand that form-theme-orange isn't officially supported anymore, but I had to make this change to get a legacy app running, and figured there was no harm in submitting a PR. 
